### PR TITLE
feat: add open book markdown editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # MDDEditor
-A lightweight markdown editor.
+
+A lightweight markdown editor presented as an open book. The left page is a markdown editor and the right page displays the rendered preview.
+
+## Usage
+
+Open `index.html` in a modern browser. The left page is a markdown editing area. As you type, the right page updates to show the formatted output.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Markdown Book Editor</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+</head>
+<body>
+  <div class="book">
+    <section class="page left">
+      <textarea id="markdown-input" placeholder="Type markdown here..."></textarea>
+    </section>
+    <section class="page right">
+      <div id="markdown-preview"></div>
+    </section>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mddeditor",
+  "version": "1.0.0",
+  "description": "Simple open-book style markdown editor",
+  "scripts": {
+    "test": "echo 'No tests specified' && exit 0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const input = document.getElementById('markdown-input');
+  const preview = document.getElementById('markdown-preview');
+
+  const render = () => {
+    const text = input.value;
+    preview.innerHTML = marked.parse(text);
+  };
+
+  input.addEventListener('input', render);
+
+  // Sample content
+  input.value = '# Welcome to MDDEditor\n\nStart typing markdown on the left page!';
+  render();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,66 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background: #ececec;
+}
+
+.book {
+  display: flex;
+  height: 100vh;
+  width: 100%;
+  max-width: 100vw;
+}
+
+.page {
+  flex: 1;
+  padding: 1rem;
+  background: #fffbea;
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.1);
+  overflow: auto;
+}
+
+.left {
+  border-right: 1px solid #ccc;
+}
+
+#markdown-input {
+  width: 100%;
+  height: 100%;
+  border: none;
+  resize: none;
+  outline: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 1rem;
+}
+
+#markdown-preview {
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
+/* Mimic an open book edge */
+.page.left::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: -0.5px;
+  width: 1px;
+  height: 100%;
+  background: #ccc;
+}
+
+.page.right::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -0.5px;
+  width: 1px;
+  height: 100%;
+  background: #ccc;
+}
+
+.page {
+  position: relative;
+}


### PR DESCRIPTION
## Summary
- add open-book layout with markdown editor on left and preview on right
- include basic styles and script for markdown rendering
- document usage and provide package.json with placeholder test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa6921ddd48326a80f0f50e71be65d